### PR TITLE
renderengine: Skip cross-frame blur cache for dynamic blur input

### DIFF
--- a/libs/renderengine/skia/SkiaRenderEngine.cpp
+++ b/libs/renderengine/skia/SkiaRenderEngine.cpp
@@ -955,6 +955,16 @@ void SkiaRenderEngine::drawLayersInternal(
         if (mBlurFilter && layerHasBlur(layer, ctModifiesAlpha)) {
             std::unordered_map<uint32_t, sk_sp<SkImage>> cachedBlurs;
 
+            // Tracks whether any layer below the blur carries a buffer. A
+            // GraphicBuffer id is stable for the lifetime of the buffer object,
+            // but producers such as video players recycle a small buffer pool
+            // and write new content into the same buffer in place. The id (and
+            // geometry) therefore cannot detect those content updates, so the
+            // cross-frame cache must not be consulted when buffer-backed content
+            // is present below the blur. Only fully static scenes (solid-color
+            // or effect-only layers) are eligible for the cross-frame cache.
+            bool blurInputHasDynamicContent = false;
+
             auto computeBlurInputHash = [&]() -> uint64_t {
                 uint64_t h = 14695981039346656037ULL;
                 const auto mix = [&h](uint64_t v) {
@@ -970,6 +980,7 @@ void SkiaRenderEngine::drawLayersInternal(
                     if (&l == &layer) break;
                     if (l.source.buffer.buffer) {
                         mix(l.source.buffer.buffer->getId());
+                        blurInputHasDynamicContent = true;
                     }
                     mixFloat(float(l.alpha));
                     const auto& m = l.geometry.positionTransform;
@@ -1067,18 +1078,25 @@ void SkiaRenderEngine::drawLayersInternal(
                         (layer.backgroundBlurRadius > 0 || !layer.blurRegions.empty())
                                 ? computeBlurInputHash()
                                 : 0;
+                // computeBlurInputHash sets blurInputHasDynamicContent as a side
+                // effect, so it must run before deciding cache eligibility.
+                const bool blurCacheEligible = !blurInputHasDynamicContent;
 
                 if (layer.backgroundBlurRadius > 0) {
                     SFTRACE_NAME("BackgroundBlur");
                     sk_sp<SkImage> blurredImage =
-                            lookupBlurCache(layer.backgroundBlurRadius, blurRectI,
-                                            blurInputHash);
+                            blurCacheEligible
+                                    ? lookupBlurCache(layer.backgroundBlurRadius, blurRectI,
+                                                      blurInputHash)
+                                    : nullptr;
                     if (!blurredImage) {
                         blurredImage =
                                 mBlurFilter->generate(context, layer.backgroundBlurRadius,
                                                       blurInput, blurRect);
-                        storeBlurCache(blurredImage, layer.backgroundBlurRadius, blurRectI,
-                                       blurInputHash);
+                        if (blurCacheEligible) {
+                            storeBlurCache(blurredImage, layer.backgroundBlurRadius, blurRectI,
+                                           blurInputHash);
+                        }
                     }
 
                     cachedBlurs[layer.backgroundBlurRadius] = blurredImage;
@@ -1093,12 +1111,17 @@ void SkiaRenderEngine::drawLayersInternal(
                     if (cachedBlurs[region.blurRadius] == nullptr) {
                         SFTRACE_NAME("BlurRegion");
                         sk_sp<SkImage> blurredImage =
-                                lookupBlurCache(region.blurRadius, blurRectI, blurInputHash);
+                                blurCacheEligible
+                                        ? lookupBlurCache(region.blurRadius, blurRectI,
+                                                          blurInputHash)
+                                        : nullptr;
                         if (!blurredImage) {
                             blurredImage = mBlurFilter->generate(context, region.blurRadius,
                                                                  blurInput, blurRect);
-                            storeBlurCache(blurredImage, region.blurRadius, blurRectI,
-                                           blurInputHash);
+                            if (blurCacheEligible) {
+                                storeBlurCache(blurredImage, region.blurRadius, blurRectI,
+                                               blurInputHash);
+                            }
                         }
                         cachedBlurs[region.blurRadius] = blurredImage;
                     }


### PR DESCRIPTION
The cross-frame blur cache added in f5ccc185cb keys cached blur images on a fingerprint of the layers below the blur, mixing in each layer's GraphicBuffer::getId(), alpha, transform and boundaries. getId() returns mId, which is assigned once at allocation and is stable for the lifetime of the buffer object. Video producers (e.g. TikTok) recycle a small buffer pool and write a new frame into the same buffer in place, so the id stays constant while the pixels change.

When the QS shade is expanded over a playing video, the shade's background-blur layer covers the screen and its blur input is the video below it. The video pool cycles through only a few buffer ids, and with a held panel the blur radius and blurRect are constant, so the fingerprint collapses to a handful of values that all fit in the 4-entry cache. After the first cycle every lookup hits and generate() is skipped, leaving the on-screen blurred backdrop frozen even though the video keeps decoding.

Neither the buffer id, the acquire fence nor the geometry can detect an in-place content update at composition time, so any buffer-backed layer below the blur must be treated as dynamic. Track this while computing the fingerprint and bypass the cross-frame cache (lookup and store) whenever dynamic content is present. Fully static scenes (solid-color or effect-only layers) remain eligible for the cache, preserving the QS-hold power win the cache was added for. The per-frame cachedBlurs map and the Output ClientCompositionRequestCache are unaffected.